### PR TITLE
[Feature/redux] Manage as redux logged-in user's information

### DIFF
--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,11 +1,12 @@
 import {createBrowserRouter, RouterProvider} from "react-router-dom";
 import TestFortTalentCategoryPage from "../store/testPages/TestFortTalentCategoryPage.jsx";
 import TestForRegionCategoryPage from "../store/testPages/TestForRegionCategoryPage.jsx";
+import TestForAuthSlicePage from "../store/testPages/TestForAuthSlicePage.jsx";
 
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <TestForRegionCategoryPage />,
+        element: <TestForAuthSlicePage />,
         // errorElement:
         // children:
     }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -15,3 +15,9 @@ const AUTH_REQUIRED = '/api/joayong';
 export const categoryApi = {
   getRegionAndTalentCategory : `${API_URL}${AUTH_REQUIRED}/category`
 };
+
+// 로그인, 로그아웃 관련 API
+export const authApi = {
+  login : `${API_URL}${AUTH_NOT_REQUIRED}/login`, // 로그인(유저 + 로그인 여부 반환)
+  me : `${API_URL}${AUTH_REQUIRED}/user/me` // 유저 정보 반환(자동 로그인인 경우 이 api로 user정보 조회함)
+};

--- a/src/services/fetchWithUs.js
+++ b/src/services/fetchWithUs.js
@@ -2,13 +2,14 @@ const fetchWithAuth = async (url, options = {}) => {
 
     const token = localStorage.getItem("accessToken");
 
-    if (!token) {
+    if (!token || token === "undefined") {
+        console.log('token 없을 때 로직 작동');
         return fetch(url, { ...options });
     }
 
     const headers = {
         ...options.headers,
-        Authorization: `Bearer {token}`,
+        Authorization: `Bearer ${token}`,
     };
 
     try {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,15 +2,16 @@
 import {configureStore} from "@reduxjs/toolkit";
 import {talentCategorySlice} from "./slices/talentCategorySlice.js";
 import {regionCategorySlice} from "./slices/regionCategorySlice.js";
+import {authSlice} from "./slices/authSlice.js";
 
 // 1. index.js 파일에 configureStore()로 store 생성 (안에는 reducer)
 // 4. app.jsx에서 app를 <Provider store={store}>로 감싸준다.
 const store = configureStore({
     reducer: {
         talentCategory: talentCategorySlice.reducer,
-        regionCategory: regionCategorySlice.reducer
+        regionCategory: regionCategorySlice.reducer,
+        auth: authSlice.reducer
     }
 })
 
 export { store };
-

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -1,1 +1,62 @@
-// redux 사용을 위한 slice를 정의하는 파일
+import {createSlice} from "@reduxjs/toolkit";
+import fetchWithUs from "../../services/fetchWithUs.js";
+import {authApi} from "../../services/api.js";
+
+const initialState = {
+    user : null,
+};
+
+const authSlice = createSlice({
+    name: "auth",
+    initialState: initialState,
+    reducers: {
+        // 로그인을 하면,
+        // 1) redux에 /login으로 받은 정보 + /me로 받은 정보 userBasicInfo에 저장
+        // 2) localStorage에 accessToken 저장
+        // 3) fetchDetailedUserInfo 함수로 user에 세부 정보까지 담아야 함
+        login(state, action) {
+            state.user = action.payload;
+            localStorage.setItem("accessToken", action.payload.accessToken);
+        },
+        logout(state) {
+            state.user = null;
+            localStorage.removeItem("accessToken");
+        },
+        // 로그인 후 /me에서 추가 정보를 받아서 저장하는 액션
+        setUserDetailedInfo(state, action) {
+            if (state.user) {
+                // 기존 user에 세부 정보 추가
+                state.user = { ...state.user, ...action.payload };
+            }
+        },
+    },
+});
+
+// /me에서 사용자 세부 정보를 가져온 후, redux의 user 객체에 추가로 저장해주는 함수
+const fetchMe = () => async (dispatch) => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+        try {
+            // /me API 호출
+            const response = await fetchWithUs(authApi.me, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                // 로그인 구현 전 테스트용으로 email 수기 입력
+                // body: JSON.stringify({email: 'abcd@naver.com'})
+            });
+            if (!response.ok) return;
+            const userData = await response.json();
+            // 세부 정보를 redux에 저장
+            dispatch(authActions.setUserDetailedInfo(userData));
+        } catch (error) {
+            console.error("사용자 정보를 가져오는 데 실패했습니다.", error);
+        }
+    }
+};
+
+
+const authActions = authSlice.actions;
+
+export { authActions, authSlice, fetchMe };

--- a/src/store/slices/manual.md
+++ b/src/store/slices/manual.md
@@ -1,14 +1,18 @@
 ## 재능 카테고리 불러오기
 ### 1. !! 주의사항 : category 데이터의 경우, useIntializeTalentCategoryData() 훅을 통해서 데이터를 fetch 해와야 합니다.
-  > // state.talenTCategory.talentCategories 이렇게 해야 리스트를 반환합니다.<br>
-  > // FYI. state.talentCategory까지만 가져오면 {talentCategories(실제 리스트), status(fetch 됐는지 여부 등) 등 다른 정보도 포함된 객체를 반환합니다.}<br>
-  > useSelector((state) => state.talentCategory.talentCategories); <br>
-  > // 필수로 아래 hook까지 호출해줘야, fetch된 데이터 가져옴<br>
-  > useInitializeTalentCategoryData();<br>
-  - redux에서 initialState를 비동기인 fetch로 가져온 값을 설정할 경우,
-    fetch가 되기 전에 initialState가 설정되어 데이터를 가져오지 못할 수 있는 문제가 발생합니다.
-     하여 커스텀 훅인 useInitializeTalentCategoryData를 통해 먼저 fetch를 하여, state 값을 업데이트 해주어야 합니다.
-  - 그럼에도 불구하고 그냥 loader를 쓰지 않고 redux를 쓰는 이유는, 응답에 따른 처리까지 redux로 효율적으로 관리 가능하기 때문입니다.
+> // state.talenTCategory.talentCategories 이렇게 해야 리스트를 반환합니다.<br>
+> // FYI. state.talentCategory까지만 가져오면 {talentCategories(실제 리스트), status(fetch 됐는지 여부 등) 등 다른 정보도 포함된 객체를 반환합니다.}<br>
+> useSelector((state) => state.talentCategory.talentCategories); <br>
+> // 필수로 아래 hook까지 호출해줘야, fetch된 데이터 가져옴<br>
+> useInitializeTalentCategoryData();<br>
+> <br>
+> 값 수정 <br>
+> const dispatch = useDispatch();  <br>
+> dispatch(talentCategoryAction.setCategory('변경된 값'));  <br>
+- redux에서 initialState를 비동기인 fetch로 가져온 값을 설정할 경우,
+  fetch가 되기 전에 initialState가 설정되어 데이터를 가져오지 못할 수 있는 문제가 발생합니다.
+  하여 커스텀 훅인 useInitializeTalentCategoryData를 통해 먼저 fetch를 하여, state 값을 업데이트 해주어야 합니다.
+- 그럼에도 불구하고 그냥 loader를 쓰지 않고 redux를 쓰는 이유는, 응답에 따른 처리까지 redux로 효율적으로 관리 가능하기 때문입니다.
 ### 2.slices > testPages에 예시 파일 있습니다.
 
 ## 지역 카테고리 불러오기
@@ -18,8 +22,29 @@
 >  useSelector((state) => state.regionCategory.regionCategories); <br>
 > // 필수로 아래 hook까지 호출해줘야, fetch된 데이터 가져옴<br>
 > useInitializeRegionCategoryData();<br>
+> <br>
+> 값 수정 <br>
+> const dispatch = useDispatch();  <br>
+> dispatch(categoryCategoryAction.setCategory('변경된 값'));  <br>
 - redux에서 initialState를 비동기인 fetch로 가져온 값을 설정할 경우,
   fetch가 되기 전에 initialState가 설정되어 데이터를 가져오지 못할 수 있는 문제가 발생합니다.
   하여 커스텀 훅인 useInitializeRegionCategoryData를 통해 먼저 fetch를 하여, state 값을 업데이트 해주어야 합니다.
 - 그럼에도 불구하고 그냥 loader를 쓰지 않고 redux를 쓰는 이유는, 응답에 따른 처리까지 redux로 효율적으로 관리 가능하기 때문입니다.
 ### 2.slices > testPages에 예시 파일 있습니다.
+
+
+## 3. 로그인 여부(isLoggedIn) 가져오기
+>    // 로그인인 된 사용자 정보를 가져오는 함수. 로그인 되지 않았으면 null 반환<br>
+>    const userInfo = useSelector((state) => state.auth.user); <br>
+>    <br>
+>   <p style="color: red"> !! 로그인 시에는, 반드시 아래 함수를 호출하여 redux에서 유저의 정보를 업데이트 해줘야 합니다. (+localstorage에 token 저장)</p><br>
+>   const disPatch = useDispatch();<br>
+>   dispatch(authActions.login(/login api로 해서 반환된 값));<br>
+>   await dispatch(fetchMe());<br>
+> <br>
+>    <p style="color: red"> !! 로그인 후에는, 반드시 아래 함수를 호출하여 redux에서 유저 정보를 없애줘야 합니다. (+localstorage에 토큰 삭제)</p><br>
+> <br>
+> dispatch(authActions.logout());<br>
+>
+>    <p style="color: red"> !! api /me에서 관리하는 값을 변경한 후에는,반드시 await dispatch(fetchMe()) 를 통해서 redux에서도 값을 수정해주어야 합니다.</p><br>
+>   await dispatch(fetchMe());<br>

--- a/src/store/slices/manual.md
+++ b/src/store/slices/manual.md
@@ -33,14 +33,14 @@
 ### 2.slices > testPages에 예시 파일 있습니다.
 
 
-## 3. 로그인 여부(isLoggedIn) 가져오기
+## 3. 로그인 사용자 정보 가져오기
 >    // 로그인인 된 사용자 정보를 가져오는 함수. 로그인 되지 않았으면 null 반환<br>
 >    const userInfo = useSelector((state) => state.auth.user); <br>
 >    <br>
 >   <p style="color: red"> !! 로그인 시에는, 반드시 아래 함수를 호출하여 redux에서 유저의 정보를 업데이트 해줘야 합니다. (+localstorage에 token 저장)</p><br>
 >   const disPatch = useDispatch();<br>
 >   dispatch(authActions.login(/login api로 해서 반환된 값));<br>
->   await dispatch(fetchMe());<br>
+>   await dispatch(fetchMe()); // api중 /me를 호출한 후, 반환된 값을 redux에 저장하는 함수<br>
 > <br>
 >    <p style="color: red"> !! 로그인 후에는, 반드시 아래 함수를 호출하여 redux에서 유저 정보를 없애줘야 합니다. (+localstorage에 토큰 삭제)</p><br>
 > <br>

--- a/src/store/slices/talentCategorySlice.js
+++ b/src/store/slices/talentCategorySlice.js
@@ -1,6 +1,8 @@
+
 import {createAsyncThunk, createSlice} from "@reduxjs/toolkit";
 import {categoryApi} from "../../services/api.js";
 import fetchWithUs from "../../services/fetchWithUs.js";
+import {regionCategoryAction} from "./regionCategorySlice.js";
 
 // - initialState를 category에 바로 fetch 해서 가져오면 안됨(비동기 작업으로 값을 못 가져올 수 있음)
 //    -> "createAsyncThunk + extraRducers"를 사용하면, createAsyncThunk 내용을 비동기 작업으로 진행화되 fetch가 fulfuill 되면 extrareducers를 통해 값이 업데이트 됨
@@ -13,6 +15,7 @@ const fetchTalentCategoryData = createAsyncThunk(
         const data = await response.json();
         return data.mainTalentList;
     }
+
 );
 
 const talentCategoryInitialState = {
@@ -60,7 +63,3 @@ const talentCategorySlice = createSlice({
 const talentCategoryAction = talentCategorySlice.actions;
 
 export {talentCategorySlice, talentCategoryAction, fetchTalentCategoryData};
-
-
-
-

--- a/src/store/testPages/TestForAuthSlicePage.jsx
+++ b/src/store/testPages/TestForAuthSlicePage.jsx
@@ -20,7 +20,7 @@ const TestForAuthSlicePage = () => {
 
     return (
         <div>
-            <h1>로그인 여부 : { userInfo ? '비로그인' : '로그인'}</h1>
+            <h1>로그인 여부 : { userInfo ? '로그인되었음. /login과 /me에서 가져온 값을 아래에 표시' : '비로그인'}</h1>
             <p>아래에는 useSelector((state) => state.auth.user)에서 가져오는 모든 값입니다</p>
             {userInfo && (
                 <div>

--- a/src/store/testPages/TestForAuthSlicePage.jsx
+++ b/src/store/testPages/TestForAuthSlicePage.jsx
@@ -1,0 +1,46 @@
+
+import React, {useEffect, useState} from 'react';
+import {useDispatch, useSelector} from "react-redux";
+import {authActions, fetchMe} from "../slices/authSlice.js";
+import fetchWithUs from "../../services/fetchWithUs.js";
+import {authApi} from "../../services/api.js";
+
+const TestForAuthSlicePage = () => {
+
+    // 로그인 여부를 가져오는 함수
+    const userInfo = useSelector((state) => state.auth.user);
+
+    const dispatch = useDispatch();
+
+    // 테스트용 가짜 아이디 로그인 정보(db에 저장해 놓은 로그인 정보)
+    const fakeUser = {
+        username: 'testUser',
+        email: 'abcd@naver.com'
+    }
+
+    return (
+        <div>
+            <h1>로그인 여부 : { userInfo ? '비로그인' : '로그인'}</h1>
+            <p>아래에는 useSelector((state) => state.auth.user)에서 가져오는 모든 값입니다</p>
+            {userInfo && (
+                <div>
+                    {Object.entries(userInfo).map(([key, value]) => (
+                        <li key={key}>
+                            <strong>{key}:</strong> {value}
+                        </li>
+                    ))}
+                </div>
+            )
+            }
+            <button onClick={async () => {
+                dispatch(authActions.login(fakeUser));
+                await dispatch(fetchMe());
+            }}>로그인 버튼</button>
+            <button onClick={() => {
+                dispatch(authActions.logout());
+            }}>로그아웃 버튼</button>
+        </div>
+    );
+};
+
+export default TestForAuthSlicePage;

--- a/src/store/testPages/TestForRegionCategoryPage.jsx
+++ b/src/store/testPages/TestForRegionCategoryPage.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import useInitializeRegionCategoryData from "../slices/regionCategoryHook.js";
+import {talentCategoryAction} from "../slices/talentCategorySlice.js";
+import {regionCategoryAction} from "../slices/regionCategorySlice.js";
 
 const TestRegionCategoryPage = () => {
 
@@ -10,6 +12,9 @@ const TestRegionCategoryPage = () => {
     // 처음에 무조건 한 번 fetch를 해 줘야 함
     // 이 파일은 fetch를 하고 redux에 저장하는 것을 저장해 놓은 hook입니다.
     useInitializeRegionCategoryData();
+
+    const dispatch = useDispatch();
+    // dispatch(regionCategoryAction.setCategory('변경된 값'));
 
     return (
         <div>

--- a/src/store/testPages/TestFortTalentCategoryPage.jsx
+++ b/src/store/testPages/TestFortTalentCategoryPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import useInitializeTalentCategoryData from "../slices/talentCategoryHook.js";
+import {talentCategoryAction} from "../slices/talentCategorySlice.js";
 
 const TestTalentCategoryPage = () => {
 
@@ -10,6 +11,9 @@ const TestTalentCategoryPage = () => {
     // 처음에 무조건 한 번 fetch를 해 줘야 함
     // 이 파일은 fetch를 하고 redux에 저장하는 것을 저장해 놓은 hook입니다.
     useInitializeTalentCategoryData();
+
+    const dispatch = useDispatch();
+    // dispatch(talentCategoryAction.setCategory('변해줄값'));
 
     return (
         <div>


### PR DESCRIPTION
## 📌 PR 요약
- 로그인한 유저의 정보를 redux로 관리합니다.

## 📌 변경 사항
- 유저 이메일 뿐만 아니라, 유저의 게시글 등 api 중 /me, /login 에서 전달한 모든 정보를 redux로 관리합니다.

## 📌 진행해야 할 사항
💡  유저 정보를 redux로 관리하기 위해서는, /me, /login에서 관리하는 정보가 변경될 경우 반드시 아래 redux 함수로 변경해야 합니다.💡
![image](https://github.com/user-attachments/assets/d52b67f5-22d8-4c0f-a0a2-bde47e6a0089)

## 📌 테스트 결과
- [x] 정상 작동 확인

## 📌 기타
- manual.md에 사용법 기입하였음
- store>slices>testPage에서 예시 페이지 확인 가능
